### PR TITLE
add german translation

### DIFF
--- a/LibreNews-App/src/main/res/values-de/arrays.xml
+++ b/LibreNews-App/src/main/res/values-de/arrays.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="refresh_rates">
+        <item>1 Minute</item>
+        <item>2 Minuten</item>
+        <item>5 Minuten</item>
+        <item>10 Minuten</item>
+        <item>15 Minuten</item>
+        <item>30 Minuten</item>
+        <item>1 Stunde</item>
+        <item>2 Stunden</item>
+        <item>3 Stunden</item>
+        <item>6 Stunden</item>
+        <item>12 Stunden</item>
+        <item>24 Stunden</item>
+    </string-array>
+    <string-array name="refresh_values">
+        <item>1</item>
+        <item>2</item>
+        <item>5</item>
+        <item>10</item>
+        <item>15</item>
+        <item>30</item>
+        <item>60</item>
+        <item>120</item>
+        <item>180</item>
+        <item>360</item>
+        <item>720</item>
+        <item>1440</item>
+    </string-array>
+    <string-array name="channels">
+        <item>Ankündigungen</item>
+        <item>Eilmeldungen</item>
+    </string-array>
+    <string-array name="default_channels">
+        <item>Ankündigungen</item>
+        <item>Eilmeldungen</item>
+    </string-array>
+</resources>

--- a/LibreNews-App/src/main/res/values-de/strings.xml
+++ b/LibreNews-App/src/main/res/values-de/strings.xml
@@ -1,0 +1,45 @@
+<resources>
+    <string name="app_name">LibreNews</string>
+    <string name="server_settings_label">Servereinstellungen</string>
+    <string name="default_server_url">https://librenews.io/api</string>
+    <string name="server_url_label">Serveradresse</string>
+    <string name="refresh_rate_label">Synchronisationsrate</string>
+    <string name="notification_preferences_label">Benachrichtigungseinstellungen</string>
+    <string name="notifications_enabled_label">Benachrichtigungen aktiviert</string>
+    <string name="auto_refresh_label">Automatisch synchronisieren</string>
+    <string name="server_url_description">Server für Nachrichtenupdates (muss HTTPS sein).</string>
+    <string name="auto_refresh_description">Ob im Hintergrund automatisch synchronisiert werden soll.</string>
+    <string name="refresh_rate_description">Wie oft LibreNews den Server kontaktieren soll, um neue Nachrichten zu erhalten.</string>
+    <string name="notification_sound_label">Benachrichtigungston</string>
+    <string name="notification_sound_description">Dieser Ton wird abgespielt, wenn neue Nachrichten eintreffen.</string>
+    <string name="notifications_enabled_description">Ob LibreNews Ihnen Benachrichtigungen senden soll.</string>
+    <string name="internal_storage_setup_fail">Fehler beim Konfigurieren des internen Speicher!</string>
+    <string name="internal_storage_read_fail">Fehler beim Lesen des internen Speicher!</string>
+    <string name="invalid_server_url">Ungültige Serveradresse!</string>
+    <string name="debug_label">Debug</string>
+    <string name="debug_mode_label">Debug-Modus</string>
+    <string name="debug_mode_description">Ob LibreNews Ihnen Benachrichtigungen zur Fehlererkennung senden soll.</string>
+    <string name="title_activity_settings">Einstellungen</string>
+    <string name="pref_header_notifications">Benachrichtigungen</string>
+    <string name="action_settings">Einstellungen</string>
+    <string name="channels_label">Kanäle</string>
+    <string name="channels_description">Wählen Sie die Kanäle aus, über die Sie informiert werden möchten.</string>
+    <string name="refresh_label">Aktualisieren</string>
+    <string name="https_required">Serveradresse muss HTTPS sein</string>
+    <string name="notifications_disabled">Benachrichtigungen deaktiviert</string>
+    <string name="sync_disabled">Synchronisation deaktiviert</string>
+    <string name="status_text" formatted="false">Synchronisiere alle {rate}</string>
+    <string name="short_description">
+    <![CDATA[
+    Eilmeldungen sind wichtige Kanäle über die wir Informationen erhalten. LibreNews versucht dieses Medium zu demokratisieren, in dem es einen minimalistischen, freien, open source, schnellen, sicheren und dezentralisierten Benachrichtigunsdienst abietet, der fast auf jedem Smartphone läuft.
+    ]]>
+    </string>
+
+    <string name="title_activity_welcome">Willkommen bei LibreNews</string>
+    <string name="short_description_of_app">LibreNews bietet einen werbefreien, dezentralisierten und sicheren Benachrichtigunsdienst an.</string>
+    <string name="how_to_use">Sie werden die meiste Zeit nur über Benachrichtigungen mit LibreNews interagieren, da die App selbst nur für Einstellungen zuständig ist.\n\nWenn Sie den Standardserver verwenden, erhalten Sie circa drei Nachrichten pro Tag.</string>
+    <string name="final_notes_welcome_screen">LibreNews verfolgt Sie in keinster Weise und ist werbefrei. Da die App komplett open-source ist, kann jeder den Programm-Code einsehen.</string>
+    <string name="start_app">LIBRENEWS STARTEN</string>
+    <string name="wifi_sync_only_label">Nur über WLAN synchronisieren</string>
+    <string name="wifi_sync_only_description">Ob LibreNews nur über WLAN synchronisieren soll und nicht über mobile Daten. Eine Synchronisation benötigt circa 9 kB Daten (weniger als 1% eines Megabyte).</string>
+</resources>

--- a/LibreNews-App/src/main/res/values-de/strings.xml
+++ b/LibreNews-App/src/main/res/values-de/strings.xml
@@ -35,7 +35,7 @@
     ]]>
     </string>
 
-    <string name="title_activity_welcome">Willkommen bei LibreNews</string>
+    <string name="title_activity_welcome">Über LibreNews</string>
     <string name="short_description_of_app">LibreNews bietet einen werbefreien, dezentralisierten und sicheren Benachrichtigunsdienst an.</string>
     <string name="how_to_use">Sie werden die meiste Zeit nur über Benachrichtigungen mit LibreNews interagieren, da die App selbst nur für Einstellungen zuständig ist.\n\nWenn Sie den Standardserver verwenden, erhalten Sie circa drei Nachrichten pro Tag.</string>
     <string name="final_notes_welcome_screen">LibreNews verfolgt Sie in keinster Weise und ist werbefrei. Da die App komplett open-source ist, kann jeder den Programm-Code einsehen.</string>


### PR DESCRIPTION
Three notes:
Make the url non translatable?
Do I have to translate {rate}?
You use "refresh rate" and "sync disabled". Isn't both a sync, so shouldn't be only one term used?