### PR TITLE
Wi-Fi and sync

### DIFF
--- a/LibreNews-App/src/main/res/values/strings.xml
+++ b/LibreNews-App/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="https_required">server must be HTTPS</string>
     <string name="notifications_disabled">notifications disabled</string>
     <string name="sync_disabled">sync disabled</string>
-    <string name="status_text" formatted="false">syncing every {rate}</string>
+    <string name="status_text" formatted="false">sync every {rate}</string>
     <string name="short_description">
     <![CDATA[
     Breaking news notifications are among the most important channels by which we receive information. LibreNews aims to democratize this medium by providing a minimalist, free, open source, fast, secure, and decentralized news notification service that will run on almost any phone.
@@ -40,7 +40,7 @@
     <string name="how_to_use">You\'ll mostly interact with LibreNews through its notifications, as the app itself is just settings. \n\nYou\'ll probably get around 3 breaking news notifications per day, if you stick with the default settings.</string>
     <string name="final_notes_welcome_screen">LibreNews doesn\'t track you in any way, and doesn\'t have ads. It\'s completely open source, making the code free for anyone to see.</string>
     <string name="start_app">GO TO LIBRENEWS</string>
-    <string name="wifi_sync_only_label">WiFi sync only</string>
-    <string name="wifi_sync_only_description">Whether LibreNews should sync only over WiFi (and not over cellular data). A LibreNews sync uses about 9 kB of data (less than 1% of a megabyte).</string>
+    <string name="wifi_sync_only_label">Wi-Fi sync only</string>
+    <string name="wifi_sync_only_description">Whether LibreNews should sync only over Wi-Fi (and not over cellular data). A LibreNews sync uses about 9 kB of data (less than 1% of a megabyte).</string>
     <string name="app_info_label">Info</string>
 </resources>


### PR DESCRIPTION
Wi-Fi as per https://en.wikipedia.org/wiki/Wi-Fi

"Sync" partly solves the space issue with the string overlapping "INFO"
another fix would be to shorten to min/sec/h. etc