### PR TITLE
Fetch channels from server

### DIFF
--- a/LibreNews-App/src/main/java/app/librenews/io/librenews/controllers/FlashManager.java
+++ b/LibreNews-App/src/main/java/app/librenews/io/librenews/controllers/FlashManager.java
@@ -304,6 +304,7 @@ public class FlashManager {
                         @Override
                         public void run() {
                             if(MainFlashActivity.activeInstance != null){
+                                onDone();
                                 MainFlashActivity.activeInstance.regenerateToolbarStatus();
                             }
                         }
@@ -345,5 +346,20 @@ public class FlashManager {
             }
         };
         mainHandler.post(myRunnable);
+    }
+
+    public interface DoneCallback{
+        void onDone();
+    }
+
+    ArrayList<DoneCallback> callbacks = new ArrayList<DoneCallback>();
+    public void addDoneCallback(DoneCallback d) {
+        this.callbacks.add(d);
+    }
+
+    public void onDone(){
+        for (DoneCallback d : callbacks) {
+            d.onDone();
+        }
     }
 }

--- a/LibreNews-App/src/main/java/app/librenews/io/librenews/controllers/FlashRetreiver.java
+++ b/LibreNews-App/src/main/java/app/librenews/io/librenews/controllers/FlashRetreiver.java
@@ -1,8 +1,10 @@
 package app.librenews.io.librenews.controllers;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Debug;
+import android.preference.PreferenceManager;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -15,6 +17,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -70,6 +74,17 @@ public class FlashRetreiver {
             String data = sb.toString();
             JSONObject jsonData = new JSONObject(data);
             serverName = jsonData.getString("server");
+
+            JSONArray channels = jsonData.getJSONArray("channels");
+            HashSet<String> available_channels = new HashSet<String>();
+            for (int i = 0; i < channels.length(); i++) {
+                available_channels.add(channels.getString(i));
+            }
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putStringSet("available_channels", available_channels);
+            editor.apply();
+
             flashes = convertJsonToFlashes(jsonData.getJSONArray("latest"));
         }
         sendDebugNotification("Flashes found: " + flashes.length, context);

--- a/LibreNews-App/src/main/java/app/librenews/io/librenews/views/SettingsActivityFragment.java
+++ b/LibreNews-App/src/main/java/app/librenews/io/librenews/views/SettingsActivityFragment.java
@@ -1,21 +1,34 @@
 package app.librenews.io.librenews.views;
 
 import android.content.SharedPreferences;
+import android.preference.MultiSelectListPreference;
 import android.preference.PreferenceFragment;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import app.librenews.io.librenews.R;
 import app.librenews.io.librenews.controllers.FlashManager;
 import app.librenews.io.librenews.controllers.SyncManager;
 
 public class SettingsActivityFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener{
+    SharedPreferences prefs;
+
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
         PreferenceManager.getDefaultSharedPreferences(getActivity()).registerOnSharedPreferenceChangeListener(this);
+        MultiSelectListPreference pref = (MultiSelectListPreference) findPreference("channels");
+        prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+        Set<String> channels = prefs.getStringSet("available_channels", new HashSet<String>());
+        CharSequence[] achannels = channels.toArray(new CharSequence[channels.size()]);
+        pref.setEntries(achannels);
+        pref.setEntryValues(achannels);
     }
 
     @Override
@@ -23,7 +36,21 @@ public class SettingsActivityFragment extends PreferenceFragment implements Shar
                                           String key) {
         System.out.println(key + " changed!");
         if(key.equals("refresh_preference") || key.equals("automatically_refresh")){
-            new SyncManager(getView().getContext(), new FlashManager(getView().getContext())).startSyncService();
+            FlashManager fmgr = new FlashManager(getView().getContext());
+            new SyncManager(getView().getContext(), fmgr).startSyncService();
+        } else if (key.equals("server_url")) {
+            FlashManager fmgr = new FlashManager(getView().getContext());
+            fmgr.addDoneCallback(new FlashManager.DoneCallback() {
+                @Override
+                public void onDone() {
+                    MultiSelectListPreference pref = (MultiSelectListPreference) findPreference("channels");
+                    Set<String> channels = prefs.getStringSet("available_channels", new HashSet<String>());
+                    CharSequence[] achannels = channels.toArray(new CharSequence[channels.size()]);
+                    pref.setEntries(achannels);
+                    pref.setEntryValues(achannels);
+                }
+            });
+            fmgr.refresh();
         }
         if (getActivity() instanceof MainFlashActivity) {
             ((MainFlashActivity)getActivity()).regenerateToolbarStatus();

--- a/LibreNews-App/src/main/res/xml/preferences.xml
+++ b/LibreNews-App/src/main/res/xml/preferences.xml
@@ -31,6 +31,7 @@
             android:summary="@string/refresh_rate_description"
             android:title="@string/refresh_rate_label" />
         <MultiSelectListPreference
+            android:id="@+id/channels"
             android:defaultValue="@array/default_channels"
             android:entries="@array/channels"
             android:entryValues="@array/channels"


### PR DESCRIPTION
This adds
  1. an `available_channels` preference
  2. a DoneCallback for the FlashManager

The SettingsActivityFragment populates the `channels` list from the `available_channels`, which is updated whenever the FlashRetreiver fetches the API.

The API is also fetched when the `server_url` is changed and the callback is used to update the channels list.

This allows to use servers that use more/other channels than the default set and fixes #24.